### PR TITLE
Updates to example d7.

### DIFF
--- a/d1/myapp.sh
+++ b/d1/myapp.sh
@@ -1,2 +1,1 @@
-printf "Hi Developers!"
-
+printf "Hi Developers!\n"

--- a/d1/readme.md
+++ b/d1/readme.md
@@ -4,7 +4,7 @@ It depends on the code and the dependencies...
 In general it's extremely easy
 
 # Exposed Tech
-+ possibly the simplest app in the world with mycode wrapped in a myapp container
++ Possibly the simplest app in the world with mycode wrapped in a myapp container
 + intro to Dockerfile declarative definition and its simple & portable commands
 
 # Focus
@@ -21,7 +21,7 @@ that will create a container image called ```myapp``` tagged as ```1```
 ```
 $ docker run myapp:1
 ```  
-observer the output and consider what just happened  
+Observe the output and consider what just happened  
 + the container was started from the local repository
 + the container run and
 + we saw the output

--- a/d7/Dockerfile
+++ b/d7/Dockerfile
@@ -27,7 +27,7 @@ RUN iris start $ISC_PACKAGE_INSTANCENAME \
     && iris session $ISC_PACKAGE_INSTANCENAME -U %SYS "##class(App.Installer).implementDesiredSystemState()" \
     && iris session $ISC_PACKAGE_INSTANCENAME -U %SYS "##class(SYS.Container).PreventFailoverMessage()" \
     && iris session $ISC_PACKAGE_INSTANCENAME -U %SYS "##class(SYS.Container).PreventJournalRolloverMessage()" \
-    && iris session $ISC_PACKAGE_INSTANCENAME -U %SYS "##class(SYS.Container).SetMonitorStateOK(\"irisowner\")" \
+    && iris session $ISC_PACKAGE_INSTANCENAME -U %SYS "##class(SYS.Container).SetMonitorStateOK()" \
     && iris session $ISC_PACKAGE_INSTANCENAME -U %SYS "##class(SYS.Container).QuiesceForBundling()" \
     && iris session $ISC_PACKAGE_INSTANCENAME -U %SYS "##class(Security.Users).UnExpireUserPasswords(\"*\")" \
     && iris stop $ISC_PACKAGE_INSTANCENAME quietly

--- a/d7/readme.md
+++ b/d7/readme.md
@@ -30,12 +30,12 @@ USER irisowner
 + The subdirectory ./MYDATA is where the data database is located. This directory will be bind mounted by the IRIS container and will be the database of the MYAPP [namespace](https://docs.intersystems.com/irislatest/csp/docbook/DocBook.UI.Page.cls?KEY=GORIENT_ch_enviro) and app.
 + Please note in the IRIS section of the Dockerfile new utilities that will grace 2019.3. They are useful as one prepares a clean application container [SYS.Container](link-TBD)
 + Requirements: to successfully *build* & *run* the **buildContainer.sh** you need to have  
-	a) the InterSystems IRIS *2019.3 Preview* and  
-	b) a valid *iris.key* 
-	+ as soon as the 2019.3 CE edition will be published the requirements can be ignored. IOW as soon as the InterSystems IRIS 2019.3 Community Edition will be available [in the Docker Hub Registry](https://hub.docker.com/_/intersystems-iris-data-platform), you will not need the Preview version nor the key.
+	a) InterSystems IRIS 2019.3 or later and  
+	b) a valid *iris.key* (note that the one in the repository is empty)
+	+ If you use InterSystems IRIS 2019.3 Community Edition [from the Docker Hub Registry](https://hub.docker.com/_/intersystems-iris-data-platform), you will not need the key.
 + if the above requirements are satisfied, run the following commands to
 	+ build the container image that will have a new MYCODE db and a MYAPP namespace
-	+ runt the container that will bind mount the ```$PWD/MYDATA/IRIS.DAT``` as the MYDATA database in the InterSystems IRIS instance running in the container  
+	+ run the container that will bind mount the ```$PWD/MYDATA/IRIS.DAT``` as the MYDATA database in the InterSystems IRIS instance running in the container.  Make sure that the IRIS user within the container (irisowner, UID 51773. GID 52773) has privilege to write to $PWD/MYDATA and $PWD/MYDATA/IRIS.DAT.  If not, the application will receive <PROTECT> errors and fail.
 
 ```
 $ ./buildContainer.sh  

--- a/d7/run.sh
+++ b/d7/run.sh
@@ -4,6 +4,7 @@
 rm -f ./MYDATA/iris.lck
 
 docker run -d \
+  --rm \
   -p 52773:52773 \
   -v $PWD:/ISC \
   -v $PWD/MYDATA:/MYDATA \


### PR DESCRIPTION
Fixed invocation of SYS.Container.SetMonitorStateOK which does not take
a parameter.
Added --rm option to docker run in run.sh.
Updated the readme because we are now past the 2019.3 preview; added
information about directory permissions.